### PR TITLE
Added scrollable settings menu and sector limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Viini ruletti</title>
+    <title>Viiniruletti</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -12,6 +12,8 @@ const Row = ({ obj, onLabelChange, onColorChange, onRowRemove, headerComponent})
   )
 }
 
+const MIN_SECTORS = 2;
+const MAX_SECTORS = 20;
 
 export default function SettingsMenu({ sectors, setSectors, showMenu = false }) {
 
@@ -21,14 +23,17 @@ export default function SettingsMenu({ sectors, setSectors, showMenu = false }) 
 
 
   function _addRow() {
+    if (sectors.length >= MAX_SECTORS) return;
     setSectors((prev) => ([...prev, { id: generateUniqueID(), label: "", color: "#ffffff" }]))
   }
 
   function _removeRow() {
+    if (sectors.length <= MIN_SECTORS) return;
     setSectors((prev) => prev.slice(0, -1))
   }
 
   function onRowRemove(index) {
+    if (sectors.length <= MIN_SECTORS) return;
     setSectors((prev) => {
 
       const newArr = prev.filter((item, prevIndex) => {
@@ -104,7 +109,7 @@ export default function SettingsMenu({ sectors, setSectors, showMenu = false }) 
     <div id='settings-menu-container' className={showMenu ? '' : 'hidden'}>
 
       
-      <h3>Sektorit</h3>
+      <h3>Sektorit ({sectors.length}/{MAX_SECTORS})</h3>
 
       <div id='settings-menu-row-container' className="row-container">
 
@@ -126,9 +131,10 @@ export default function SettingsMenu({ sectors, setSectors, showMenu = false }) 
         <button
           id='add-row-button'
           className="settings-menu-button"
+          disabled={sectors.length >= MAX_SECTORS}
           onClick={_addRow}>+</button>
         <button id='remove-row-button'
-          style={sectors.length > 2 ? { display: 'block' } : { display: 'none' }}
+          style={sectors.length > MIN_SECTORS ? { display: 'block' } : { display: 'none' }}
           className="settings-menu-button"
           onClick={_removeRow}>-</button>
       </div>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -104,6 +104,17 @@
   margin-top: 20px;
 }
 
+#settings-menu-row-container {
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  padding-right: 10px;
+  margin-right: -10px;
+}
+
 .settings-button-container {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
* Added minimum (`MIN_SECTORS = 2`) and maximum (`MAX_SECTORS = 20`) sector limits
* The sector header now shows the current count and the maximum allowed
* The sector rows container has vertical scrolling when there are many sectors
* Also minor fixes™ (typo)